### PR TITLE
Changes to the App_Start.NinjectWebCommon class template file for 3.0.0-rc2

### DIFF
--- a/nuget/Content/App_Start/NinjectWebCommon.cs.pp
+++ b/nuget/Content/App_Start/NinjectWebCommon.cs.pp
@@ -3,6 +3,8 @@
 
 namespace $rootnamespace$.App_Start
 {
+    using System;
+    using System.Web;
     using Microsoft.Web.Infrastructure.DynamicModuleHelper;
 
     using Ninject;
@@ -17,7 +19,7 @@ namespace $rootnamespace$.App_Start
         /// </summary>
         public static void Start() 
         {
-            DynamicModuleUtility.RegisterModule(typeof(OnePerRequestModule));
+            DynamicModuleUtility.RegisterModule(typeof(OnePerRequestHttpModule));
             DynamicModuleUtility.RegisterModule(typeof(NinjectHttpModule));
             bootstrapper.Initialize(CreateKernel);
         }


### PR DESCRIPTION
When I installed Ninject.extensions.Wcf 3.0.0-rc2 from nuget, the App_Start.NinjectWebCommon class wouldn't compile.  These are the changes I had to make to get it to compile.

The ninject release notes mentioned that the OnePerRequestModule class had been renamed.  Since the .pp file is a template used by the WebActivator nuget package to create the .cs file after the package is installed, you probably don't have a test you can on your CI server to verify that the class works.  Hope this helps, and thanks for getting the release out when you did.
