### PR TITLE
Add RequestScopeHandler to kernel instead of SingletonScopeHandler

### DIFF
--- a/src/Ninject.Web.Common.Xml/WebCommonXmlModule.cs
+++ b/src/Ninject.Web.Common.Xml/WebCommonXmlModule.cs
@@ -34,7 +34,7 @@ namespace Ninject.Web.Common.Xml
         /// </summary>
         public override void Load()
         {
-            this.Kernel.Components.Add<IScopeHandler, SingletonScopeHandler>();
+            this.Kernel.Components.Add<IScopeHandler, RequestScopeHandler>();
         }
     }
 }


### PR DESCRIPTION
Ninject.Web.Common.Xml extension is supposed to add support for InRequestScope() in xml files via the "scope" attribute. 

In order to do that, it has to load RequestScopeHandler into the kernel, overriding the "Load" method of the NinjectModule class.

Current WebCommonXmlModule is loading the SingletonScopeHandler class which is wrong.

More info:
https://github.com/ninject/ninject.extensions.xml/wiki/Getting-started#scope-attribute-optional
