### PR TITLE
Fix bootstrap initialization race condition

### DIFF
--- a/src/Ninject.Web.Common.OwinHost/OwinBootstrapper.cs
+++ b/src/Ninject.Web.Common.OwinHost/OwinBootstrapper.cs
@@ -83,8 +83,9 @@ namespace Ninject.Web.Common.OwinHost
                 {
                     if (this.bootstrapper == null)
                     {
-                        this.bootstrapper = new Bootstrapper();
-                        this.bootstrapper.Initialize(this.CreateKernel);
+                        var initializingBootstrapper = new Bootstrapper();
+                        initializingBootstrapper.Initialize(this.CreateKernel);
+                        this.bootstrapper = initializingBootstrapper;
                     }
                 }
             }


### PR DESCRIPTION
If the createKernel func given to OwinBootstrapper took a long time to
complete, the second request to come in could skip waiting for the lock
to be released.