### PR TITLE
Make initialization of bootstraper a startup task instead of a per-request task.

### DIFF
--- a/src/Ninject.Web.Common.OwinHost/OwinAppBuilderExtensions.cs
+++ b/src/Ninject.Web.Common.OwinHost/OwinAppBuilderExtensions.cs
@@ -20,6 +20,8 @@
 namespace Ninject.Web.Common.OwinHost
 {
     using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     using Owin;
 
@@ -51,7 +53,10 @@ namespace Ninject.Web.Common.OwinHost
 
             app.Properties.Add(NinjectOwinBootstrapperKey, bootstrapper);
 
-            return app.Use(bootstrapper.Execute);
+
+            var middleware = new Func<Func<IDictionary<string, object>, Task>, Func<IDictionary<string, object>, Task>>(bootstrapper.Execute);
+
+            return app.Use(middleware);
         }  
     }
 }

--- a/src/Ninject.Web.Common.OwinHost/OwinBootstrapper.cs
+++ b/src/Ninject.Web.Common.OwinHost/OwinBootstrapper.cs
@@ -66,16 +66,11 @@ namespace Ninject.Web.Common.OwinHost
         /// <summary>
         /// The execute.
         /// </summary>
-        /// <param name="context">
-        /// The context.
-        /// </param>
-        /// <param name="next">
-        /// The next.
-        /// </param>
+        /// <param name="next">The next.</param>
         /// <returns>
-        /// The <see cref="Task"/>.
+        /// The <see cref="Func{IDictionary{string, object}, Task}"/>.
         /// </returns>
-        public async Task Execute(IOwinContext context, Func<Task> next)
+        public Func<IDictionary<string, object>, Task> Execute(Func<IDictionary<string, object>, Task> next)
         {
             if (this.bootstrapper == null)
             {
@@ -90,11 +85,13 @@ namespace Ninject.Web.Common.OwinHost
                 }
             }
 
-            using (var scope = new OwinRequestScope())
-            {
-                context.Set(NinjectOwinRequestScope, scope);
-                await next();
-            }
+            return async (context) => {
+                using (var scope = new OwinRequestScope())
+                {
+                    context[NinjectOwinRequestScope] = scope;
+                    await next(context);
+                }
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
Turn OwinBootstrapper into a MiddlewareFactory instead of a Delegate middleware.

This is an alternate fix/enhancement upon #26.  Where #26 fixed the issue with the race condition, this removes the race by executing the initialization only when Owin is executing for the first time.  The threading safety was left but is not necessary assuming normal usage.
